### PR TITLE
Added UMD version of packages at publish time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 coverage
-dist
+
+**/dist/*
+!**/dist/package.json
 
 .yarn/*
 !.yarn/releases

--- a/packages/link-config-emea/babel.config.json
+++ b/packages/link-config-emea/babel.config.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "test": {
+      "plugins": ["@babel/plugin-transform-modules-commonjs"]
+    }
+  }
+}

--- a/packages/link-config-emea/dist/package.json
+++ b/packages/link-config-emea/dist/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/packages/link-config-emea/package.json
+++ b/packages/link-config-emea/package.json
@@ -5,9 +5,13 @@
   "author": "Jean-Yves Boudreau (jean-yves.boudreau@kandy.io)",
   "license": "MIT",
   "type": "module",
+  "main": "./dist/index.umd.js",
   "module": "./src/index.js",
   "exports": {
-    "import": "./src/index.js"
+    ".": {
+      "import": "./src/index.js",
+      "require": "./dist/index.umd.js"
+    }
   },
   "homepage": "https://github.com/Kandy-IO/kandy-js-support/packages/link-config-emea#readme",
   "repository": {
@@ -18,12 +22,15 @@
     "url": "https://github.com/Kandy-IO/kandy-js-support/issues"
   },
   "files": [
-    "src/**/*"
+    "src/**/*",
+    "dist/**/*"
   ],
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "prepack": "rollup ./src/index.js -f umd -n \"Kandy.support.emea\" --extend -o ./dist/index.umd.js"
   },
   "devDependencies": {
-    "jest": "^26.4.2"
+    "jest": "^26.4.2",
+    "rollup": "^2.32.0"
   }
 }

--- a/packages/link-config-uae/babel.config.json
+++ b/packages/link-config-uae/babel.config.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "test": {
+      "plugins": ["@babel/plugin-transform-modules-commonjs"]
+    }
+  }
+}

--- a/packages/link-config-uae/dist/package.json
+++ b/packages/link-config-uae/dist/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/packages/link-config-uae/package.json
+++ b/packages/link-config-uae/package.json
@@ -5,9 +5,13 @@
   "author": "Jean-Yves Boudreau (jean-yves.boudreau@kandy.io)",
   "license": "MIT",
   "type": "module",
+  "main": "./dist/index.umd.js",
   "module": "./src/index.js",
   "exports": {
-    "import": "./src/index.js"
+    ".": {
+      "import": "./src/index.js",
+      "require": "./dist/index.umd.js"
+    }
   },
   "homepage": "https://github.com/Kandy-IO/kandy-js-support/packages/link-config-uae#readme",
   "repository": {
@@ -18,12 +22,15 @@
     "url": "https://github.com/Kandy-IO/kandy-js-support/issues"
   },
   "files": [
-    "src/**/*"
+    "src/**/*",
+    "dist/**/*"
   ],
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "prepack": "rollup ./src/index.js -f umd -n \"Kandy.support.uae\" --extend -o ./dist/index.umd.js"
   },
   "devDependencies": {
-    "jest": "^26.4.2"
+    "jest": "^26.4.2",
+    "rollup": "^2.32.0"
   }
 }

--- a/packages/link-config-us/babel.config.json
+++ b/packages/link-config-us/babel.config.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "test": {
+      "plugins": ["@babel/plugin-transform-modules-commonjs"]
+    }
+  }
+}

--- a/packages/link-config-us/dist/package.json
+++ b/packages/link-config-us/dist/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/packages/link-config-us/package.json
+++ b/packages/link-config-us/package.json
@@ -5,9 +5,13 @@
   "author": "Jean-Yves Boudreau (jean-yves.boudreau@kandy.io)",
   "license": "MIT",
   "type": "module",
+  "main": "./dist/index.umd.js",
   "module": "./src/index.js",
   "exports": {
-    "import": "./src/index.js"
+    ".": {
+      "import": "./src/index.js",
+      "require": "./dist/index.umd.js"
+    }
   },
   "homepage": "https://github.com/Kandy-IO/kandy-js-support/packages/link-config-us#readme",
   "repository": {
@@ -18,12 +22,15 @@
     "url": "https://github.com/Kandy-IO/kandy-js-support/issues"
   },
   "files": [
-    "src/**/*"
+    "src/**/*",
+    "dist/**/*"
   ],
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "prepack": "rollup ./src/index.js -f umd -n \"Kandy.support.us\" --extend -o ./dist/index.umd.js"
   },
   "devDependencies": {
-    "jest": "^26.4.2"
+    "jest": "^26.4.2",
+    "rollup": "^2.32.0"
   }
 }

--- a/packages/sdp-handlers/babel.config.json
+++ b/packages/sdp-handlers/babel.config.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "test": {
+      "plugins": ["@babel/plugin-transform-modules-commonjs"]
+    }
+  }
+}

--- a/packages/sdp-handlers/dist/package.json
+++ b/packages/sdp-handlers/dist/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/packages/sdp-handlers/package.json
+++ b/packages/sdp-handlers/package.json
@@ -5,9 +5,13 @@
   "author": "Jean-Yves Boudreau (jean-yves.boudreau@kandy.io)",
   "license": "MIT",
   "type": "module",
+  "main": "./dist/index.umd.js",
   "module": "./src/index.js",
   "exports": {
-    "import": "./src/index.js"
+    ".": {
+      "import": "./src/index.js",
+      "require": "./dist/index.umd.js"
+    }
   },
   "homepage": "https://github.com/Kandy-IO/kandy-js-support/packages/sdp-handlers#readme",
   "repository": {
@@ -18,13 +22,16 @@
     "url": "https://github.com/Kandy-IO/kandy-js-support/issues"
   },
   "files": [
-    "src/**/*"
+    "src/**/*",
+    "dist/**/*"
   ],
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "prepack": "rollup ./src/index.js -f umd -n \"Kandy.support.sdpHandlers\" --extend -o ./dist/index.umd.js"
   },
   "devDependencies": {
     "jest": "^26.4.2",
+    "rollup": "^2.32.0",
     "sdp-transform": "^2.14.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,6 +669,7 @@ __metadata:
   resolution: "@kandy-io/link-config-emea@workspace:packages/link-config-emea"
   dependencies:
     jest: ^26.4.2
+    rollup: ^2.32.0
   languageName: unknown
   linkType: soft
 
@@ -677,6 +678,7 @@ __metadata:
   resolution: "@kandy-io/link-config-uae@workspace:packages/link-config-uae"
   dependencies:
     jest: ^26.4.2
+    rollup: ^2.32.0
   languageName: unknown
   linkType: soft
 
@@ -685,6 +687,7 @@ __metadata:
   resolution: "@kandy-io/link-config-us@workspace:packages/link-config-us"
   dependencies:
     jest: ^26.4.2
+    rollup: ^2.32.0
   languageName: unknown
   linkType: soft
 
@@ -693,6 +696,7 @@ __metadata:
   resolution: "@kandy-io/sdp-handlers@workspace:packages/sdp-handlers"
   dependencies:
     jest: ^26.4.2
+    rollup: ^2.32.0
     sdp-transform: ^2.14.0
   languageName: unknown
   linkType: soft
@@ -3063,7 +3067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-fsevents@^2.1.2:
+"fsevents@^2.1.2, fsevents@~2.1.2":
   version: 2.1.3
   resolution: "fsevents@npm:2.1.3"
   dependencies:
@@ -3072,7 +3076,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.1.2#builtin<compat/fsevents>":
+"fsevents@patch:fsevents@^2.1.2#builtin<compat/fsevents>, fsevents@patch:fsevents@~2.1.2#builtin<compat/fsevents>":
   version: 2.1.3
   resolution: "fsevents@patch:fsevents@npm%3A2.1.3#builtin<compat/fsevents>::version=2.1.3&hash=127e8e"
   dependencies:
@@ -6679,6 +6683,20 @@ resolve@1.15.1:
   bin:
     rimraf: bin.js
   checksum: f0de3e445581e64a8a077af476cc30708e659f5779ec2ca2a161556d0792aa318a685923798ae22055b4ecd02b9aff444ef619578f7af53cf8e0e248031e3dee
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^2.32.0":
+  version: 2.32.0
+  resolution: "rollup@npm:2.32.0"
+  dependencies:
+    fsevents: ~2.1.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: dfe2615c617a77618a3310ac8c7276c6db2445d0b2f1a3e90e7f4e53a30d0f35da70985d37a3a6de89c343d4940562a61ef72013a31534a056fca183d3dc0c57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Even though in theory, these packages are meant to only be used in the browser and therefore could be used only as ESM, in practice they tend to also be used as CommonJS as part of bundlers, tests, or other tools that run in Node.js.

This PR adds publish processing for generating an UMD package in the `./dist/` folder.

* Added `./dist/package.json` with a simple `{ "type" : "commonjs" }` to indicate to various tools that this folder contains CommonJS scripts.
* Added rollup `prepack` script to create a UMD package at publish or package time.
    * Each UMD uses a namespace for putting the config file. 
* Added `"main"` entry to package.json files.
* Made sure to add `dist/**/*` as deployed files.
* Added babel.config.json to all packages so tests can be run at each workspace scope instead of only at root.

## Tests

1. Create a small NPM project.
2. Use `npm link` to link sdp-handlers package to be able to test local changes.
3. Import script into a CommonJS script using `require('@kandy-io/sdp-handlers')` and make sure things get imported properly.

## Follow-up

I'll have another PR for documentation on how to use these packages in the browser using plain `<script>` tags.