### PR TITLE
[KJS-170]: Migrate to the new public domains for stun/turn servers, as well as Websocket & REST Urls

### DIFF
--- a/packages/link-config-emea/CHANGELOG.md
+++ b/packages/link-config-emea/CHANGELOG.md
@@ -5,7 +5,7 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
-## 1.2.0 - 2021-06-14
+## 1.2.0 - 2021-06-17
 
 ### Changed
 

--- a/packages/link-config-emea/CHANGELOG.md
+++ b/packages/link-config-emea/CHANGELOG.md
@@ -5,6 +5,12 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
+## 1.2.0 - 2021-06-14
+
+### Changed
+
+- Changed the domain name used in configuration for all turn/stun servers.
+
 ## 1.1.0 - 2020-10-27
 
 ### Added

--- a/packages/link-config-emea/package.json
+++ b/packages/link-config-emea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kandy-io/link-config-emea",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Kandy.js EMEA Configuration",
   "author": "Jean-Yves Boudreau (jean-yves.boudreau@kandy.io)",
   "license": "MIT",

--- a/packages/link-config-emea/src/index.js
+++ b/packages/link-config-emea/src/index.js
@@ -1,27 +1,27 @@
 const config = {
   authentication: {
     server: {
-      base: 'spidr-em.genband.com'
+      base: 'webrtc-em.kandy.io'
     }
   },
   subscription: {
     websocket: {
-      server: 'spidr-em.genband.com'
+      server: 'webrtc-em.kandy.io'
     }
   },
   call: {
     iceserver: [
       {
-        url: 'turns:turn-em-1.genband.com:443?transport=tcp'
+        url: 'turns:turn-em-1.kandy.io:443?transport=tcp'
       },
       {
-        url: 'turns:turn-em-2.genband.com:443?transport=tcp'
+        url: 'turns:turn-em-2.kandy.io:443?transport=tcp'
       },
       {
-        url: 'stun:turn-em-1.genband.com:3478?transport=udp'
+        url: 'stun:turn-em-1.kandy.io:3478?transport=udp'
       },
       {
-        url: 'stun:turn-em-2.genband.com:3478?transport=udp'
+        url: 'stun:turn-em-2.kandy.io:3478?transport=udp'
       }
     ]
   }

--- a/packages/link-config-emea/test/index.test.js
+++ b/packages/link-config-emea/test/index.test.js
@@ -5,28 +5,28 @@ test('Configuration object test', () => {
     Object {
       "authentication": Object {
         "server": Object {
-          "base": "spidr-em.genband.com",
+          "base": "webrtc-em.kandy.io",
         },
       },
       "call": Object {
         "iceserver": Array [
           Object {
-            "url": "turns:turn-em-1.genband.com:443?transport=tcp",
+            "url": "turns:turn-em-1.kandy.io:443?transport=tcp",
           },
           Object {
-            "url": "turns:turn-em-2.genband.com:443?transport=tcp",
+            "url": "turns:turn-em-2.kandy.io:443?transport=tcp",
           },
           Object {
-            "url": "stun:turn-em-1.genband.com:3478?transport=udp",
+            "url": "stun:turn-em-1.kandy.io:3478?transport=udp",
           },
           Object {
-            "url": "stun:turn-em-2.genband.com:3478?transport=udp",
+            "url": "stun:turn-em-2.kandy.io:3478?transport=udp",
           },
         ],
       },
       "subscription": Object {
         "websocket": Object {
-          "server": "spidr-em.genband.com",
+          "server": "webrtc-em.kandy.io",
         },
       },
     }

--- a/packages/link-config-us/CHANGELOG.md
+++ b/packages/link-config-us/CHANGELOG.md
@@ -5,7 +5,7 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
-## 1.2.0 - 2021-06-14
+## 1.2.0 - 2021-06-17
 
 ### Changed
 

--- a/packages/link-config-us/CHANGELOG.md
+++ b/packages/link-config-us/CHANGELOG.md
@@ -5,6 +5,12 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
+## 1.2.0 - 2021-06-14
+
+### Changed
+
+- Changed the domain name used in configuration for all turn/stun servers.
+
 ## 1.1.0 - 2020-10-27
 
 ### Added

--- a/packages/link-config-us/package.json
+++ b/packages/link-config-us/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kandy-io/link-config-us",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Kandy.js US Configuration",
   "author": "Jean-Yves Boudreau (jean-yves.boudreau@kandy.io)",
   "license": "MIT",

--- a/packages/link-config-us/src/index.js
+++ b/packages/link-config-us/src/index.js
@@ -1,27 +1,27 @@
 const config = {
   authentication: {
     server: {
-      base: 'spidr-ucc.genband.com'
+      base: 'webrtc-na.kandy.io'
     }
   },
   subscription: {
     websocket: {
-      server: 'spidr-ucc.genband.com'
+      server: 'webrtc-na.kandy.io'
     }
   },
   call: {
     iceserver: [
       {
-        url: 'turns:turn-ucc-1.genband.com:443?transport=tcp'
+        url: 'turns:turn-na-1.kandy.io:443?transport=tcp'
       },
       {
-        url: 'turns:turn-ucc-2.genband.com:443?transport=tcp'
+        url: 'turns:turn-na-2.kandy.io:443?transport=tcp'
       },
       {
-        url: 'stun:turn-ucc-1.genband.com:3478?transport=udp'
+        url: 'stun:turn-na-1.kandy.io:3478?transport=udp'
       },
       {
-        url: 'stun:turn-ucc-2.genband.com:3478?transport=udp'
+        url: 'stun:turn-na-2.kandy.io:3478?transport=udp'
       }
     ]
   }

--- a/packages/link-config-us/test/index.test.js
+++ b/packages/link-config-us/test/index.test.js
@@ -5,28 +5,28 @@ test('Configuration object test', () => {
     Object {
       "authentication": Object {
         "server": Object {
-          "base": "spidr-ucc.genband.com",
+          "base": "webrtc-na.kandy.io",
         },
       },
       "call": Object {
         "iceserver": Array [
           Object {
-            "url": "turns:turn-ucc-1.genband.com:443?transport=tcp",
+            "url": "turns:turn-na-1.kandy.io:443?transport=tcp",
           },
           Object {
-            "url": "turns:turn-ucc-2.genband.com:443?transport=tcp",
+            "url": "turns:turn-na-2.kandy.io:443?transport=tcp",
           },
           Object {
-            "url": "stun:turn-ucc-1.genband.com:3478?transport=udp",
+            "url": "turn-na-1.kandy.io:3478?transport=udp",
           },
           Object {
-            "url": "stun:turn-ucc-2.genband.com:3478?transport=udp",
+            "url": "stun:turn-na-2.kandy.io:3478?transport=udp",
           },
         ],
       },
       "subscription": Object {
         "websocket": Object {
-          "server": "spidr-ucc.genband.com",
+          "server": "webrtc-na.kandy.io",
         },
       },
     }

--- a/packages/link-config-us/test/index.test.js
+++ b/packages/link-config-us/test/index.test.js
@@ -17,7 +17,7 @@ test('Configuration object test', () => {
             "url": "turns:turn-na-2.kandy.io:443?transport=tcp",
           },
           Object {
-            "url": "turn-na-1.kandy.io:3478?transport=udp",
+            "url": "stun:turn-na-1.kandy.io:3478?transport=udp",
           },
           Object {
             "url": "stun:turn-na-2.kandy.io:3478?transport=udp",


### PR DESCRIPTION
### Branch

master

### Story
https://kandyio.atlassian.net/browse/KJS-170

### Description

The changes were made based on new public domain values indicated in JIRA. The changes are done directly into master because there is no develop branch for this repo project.

To find all pertinent places that need to change, I searched for **genband.com** within Kandy.js project and only did changes for the ones that made sense.

This PR should be merged before [this one](https://github.com/Fring/Kandy.js/pull/3190)  -- see my comments in that PR

Comments:

packages/link-config-uae/index.js will continue to use values like: 

turns:ct-turn1.etisalat.ae:443?transport=tcp
turns:ct-turn2etisalat.ae:443?transport=tcp
ct-webrtc.etisalat.ae

since these value don't use the obsoleted genband.com domain.

### Tests

Just verified that unit tests pass (as part of latest PR update). 
If you think more tests are needed for these simple changes, let me know.