### PR TITLE
[KJS-379]: Update configuration for ICE servers to use new method

### DIFF
--- a/packages/link-config-emea/CHANGELOG.md
+++ b/packages/link-config-emea/CHANGELOG.md
@@ -5,7 +5,7 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
-## 1.2.1 - 2021-11-03
+## 2.0.0 - 2021-11-09
 
 ### Changed
 

--- a/packages/link-config-emea/CHANGELOG.md
+++ b/packages/link-config-emea/CHANGELOG.md
@@ -5,6 +5,12 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
+## 1.2.1 - 2021-11-03
+
+### Changed
+
+- Moved the location of ICE servers configuration within the overall configuration object, so that they are now part of a new property `defaultPeerConfig`. This new property will represent configuration for a native peer connection, thus it ensures support for full configuration on a given RTCPeerConnection. See [RTCPeerConfiguration properties](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection). `KJS-379`
+
 ## 1.2.0 - 2021-06-17
 
 ### Changed

--- a/packages/link-config-emea/src/index.js
+++ b/packages/link-config-emea/src/index.js
@@ -10,20 +10,22 @@ const config = {
     }
   },
   call: {
-    iceserver: [
-      {
-        url: 'turns:turn-em-1.kandy.io:443?transport=tcp'
-      },
-      {
-        url: 'turns:turn-em-2.kandy.io:443?transport=tcp'
-      },
-      {
-        url: 'stun:turn-em-1.kandy.io:3478?transport=udp'
-      },
-      {
-        url: 'stun:turn-em-2.kandy.io:3478?transport=udp'
-      }
-    ]
+    defaultPeerConfig: {
+      iceServers: [
+        {
+          urls: ['turns:turn-em-1.kandy.io:443?transport=tcp']
+        },
+        {
+          urls: ['turns:turn-em-2.kandy.io:443?transport=tcp']
+        },
+        {
+          urls: ['stun:turn-em-1.kandy.io:3478?transport=udp']
+        },
+        {
+          urls: ['stun:turn-em-2.kandy.io:3478?transport=udp']
+        }
+      ]
+    }
   }
 }
 

--- a/packages/link-config-emea/test/index.test.js
+++ b/packages/link-config-emea/test/index.test.js
@@ -9,20 +9,30 @@ test('Configuration object test', () => {
         },
       },
       "call": Object {
-        "iceserver": Array [
-          Object {
-            "url": "turns:turn-em-1.kandy.io:443?transport=tcp",
-          },
-          Object {
-            "url": "turns:turn-em-2.kandy.io:443?transport=tcp",
-          },
-          Object {
-            "url": "stun:turn-em-1.kandy.io:3478?transport=udp",
-          },
-          Object {
-            "url": "stun:turn-em-2.kandy.io:3478?transport=udp",
-          },
-        ],
+        "defaultPeerConfig": Object {
+          "iceServers": Array [
+            Object {
+              "urls": Array [
+                "turns:turn-em-1.kandy.io:443?transport=tcp",
+              ],
+            },
+            Object {
+              "urls": Array [
+                "turns:turn-em-2.kandy.io:443?transport=tcp",
+              ],
+            },
+            Object {
+              "urls": Array [
+                "stun:turn-em-1.kandy.io:3478?transport=udp",
+              ],
+            },
+            Object {
+              "urls": Array [
+                "stun:turn-em-2.kandy.io:3478?transport=udp",
+              ],
+            },
+          ],
+        },
       },
       "subscription": Object {
         "websocket": Object {

--- a/packages/link-config-uae/CHANGELOG.md
+++ b/packages/link-config-uae/CHANGELOG.md
@@ -5,11 +5,12 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
-## 1.2.1 - 2021-11-03
+## 2.0.0 - 2021-11-09
 
 ### Changed
 
 - Moved the location of ICE servers configuration within the overall configuration object, so that they are now part of a new property `defaultPeerConfig`. This new property will represent configuration for a native peer connection, thus it ensures support for full configuration on a given RTCPeerConnection. See [RTCPeerConfiguration properties](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection). `KJS-379`
+
 ## 1.1.0 - 2020-10-27
 
 ### Added

--- a/packages/link-config-uae/CHANGELOG.md
+++ b/packages/link-config-uae/CHANGELOG.md
@@ -5,6 +5,11 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
+## 1.2.1 - 2021-11-03
+
+### Changed
+
+- Moved the location of ICE servers configuration within the overall configuration object, so that they are now part of a new property `defaultPeerConfig`. This new property will represent configuration for a native peer connection, thus it ensures support for full configuration on a given RTCPeerConnection. See [RTCPeerConfiguration properties](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection). `KJS-379`
 ## 1.1.0 - 2020-10-27
 
 ### Added

--- a/packages/link-config-uae/src/index.js
+++ b/packages/link-config-uae/src/index.js
@@ -32,20 +32,22 @@ const config = {
     }
   },
   call: {
-    iceserver: [
-      {
-        url: 'turns:ct-turn1.etisalat.ae:443?transport=tcp'
-      },
-      {
-        url: 'turns:ct-turn2.etisalat.ae:443?transport=tcp'
-      },
-      {
-        url: 'stun:ct-turn1.etisalat.ae:3478?transport=udp'
-      },
-      {
-        url: 'stun:ct-turn2.etisalat.ae:3478?transport=udp'
-      }
-    ],
+    defaultPeerConfig: {
+      iceServers: [
+        {
+          urls: ['turns:ct-turn1.etisalat.ae:443?transport=tcp']
+        },
+        {
+          urls: ['turns:ct-turn2.etisalat.ae:443?transport=tcp']
+        },
+        {
+          urls: ['stun:ct-turn1.etisalat.ae:3478?transport=udp']
+        },
+        {
+          urls: ['stun:ct-turn2.etisalat.ae:3478?transport=udp']
+        }
+      ]
+    },
     removeH264Codecs: false,
     sdpHandlers: [removeCodecsOnSetLocalOffer]
   }

--- a/packages/link-config-uae/test/index.test.js
+++ b/packages/link-config-uae/test/index.test.js
@@ -11,20 +11,30 @@ test('Configuration object test', () => {
         },
       },
       "call": Object {
-        "iceserver": Array [
-          Object {
-            "url": "turns:ct-turn1.etisalat.ae:443?transport=tcp",
-          },
-          Object {
-            "url": "turns:ct-turn2.etisalat.ae:443?transport=tcp",
-          },
-          Object {
-            "url": "stun:ct-turn1.etisalat.ae:3478?transport=udp",
-          },
-          Object {
-            "url": "stun:ct-turn2.etisalat.ae:3478?transport=udp",
-          },
-        ],
+        "defaultPeerConfig": Object {
+          "iceServers": Array [
+            Object {
+              "urls": Array [
+                "turns:ct-turn1.etisalat.ae:443?transport=tcp",
+              ],
+            },
+            Object {
+              "urls": Array [
+                "turns:ct-turn2.etisalat.ae:443?transport=tcp",
+              ],
+            },
+            Object {
+              "urls": Array [
+                "stun:ct-turn1.etisalat.ae:3478?transport=udp",
+              ],
+            },
+            Object {
+              "urls": Array [
+                "stun:ct-turn2.etisalat.ae:3478?transport=udp",
+              ],
+            },
+          ],
+        },
         "removeH264Codecs": false,
         "sdpHandlers": Array [
           [Function],

--- a/packages/link-config-us/CHANGELOG.md
+++ b/packages/link-config-us/CHANGELOG.md
@@ -5,7 +5,7 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
-## 1.2.1 - 2021-11-03
+## 2.0.0 - 2021-11-09
 
 ### Changed
 

--- a/packages/link-config-us/CHANGELOG.md
+++ b/packages/link-config-us/CHANGELOG.md
@@ -5,6 +5,12 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
+## 1.2.1 - 2021-11-03
+
+### Changed
+
+- Moved the location of ICE servers configuration within the overall configuration object, so that they are now part of a new property `defaultPeerConfig`. This new property will represent configuration for a native peer connection, thus it ensures support for full configuration on a given RTCPeerConnection. See [RTCPeerConfiguration properties](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection). `KJS-379`
+
 ## 1.2.0 - 2021-06-17
 
 ### Changed

--- a/packages/link-config-us/src/index.js
+++ b/packages/link-config-us/src/index.js
@@ -10,20 +10,22 @@ const config = {
     }
   },
   call: {
-    iceserver: [
-      {
-        url: 'turns:turn-na-1.kandy.io:443?transport=tcp'
-      },
-      {
-        url: 'turns:turn-na-2.kandy.io:443?transport=tcp'
-      },
-      {
-        url: 'stun:turn-na-1.kandy.io:3478?transport=udp'
-      },
-      {
-        url: 'stun:turn-na-2.kandy.io:3478?transport=udp'
-      }
-    ]
+    defaultPeerConfig: {
+      iceServers: [
+        {
+          urls: ['turns:turn-na-1.kandy.io:443?transport=tcp']
+        },
+        {
+          urls: ['turns:turn-na-2.kandy.io:443?transport=tcp']
+        },
+        {
+          urls: ['stun:turn-na-1.kandy.io:3478?transport=udp']
+        },
+        {
+          urls: ['stun:turn-na-2.kandy.io:3478?transport=udp']
+        }
+      ]
+    }
   }
 }
 

--- a/packages/link-config-us/test/index.test.js
+++ b/packages/link-config-us/test/index.test.js
@@ -9,20 +9,30 @@ test('Configuration object test', () => {
         },
       },
       "call": Object {
-        "iceserver": Array [
-          Object {
-            "url": "turns:turn-na-1.kandy.io:443?transport=tcp",
-          },
-          Object {
-            "url": "turns:turn-na-2.kandy.io:443?transport=tcp",
-          },
-          Object {
-            "url": "stun:turn-na-1.kandy.io:3478?transport=udp",
-          },
-          Object {
-            "url": "stun:turn-na-2.kandy.io:3478?transport=udp",
-          },
-        ],
+        "defaultPeerConfig": Object {
+          "iceServers": Array [
+            Object {
+              "urls": Array [
+                "turns:turn-na-1.kandy.io:443?transport=tcp",
+              ],
+            },
+            Object {
+              "urls": Array [
+                "turns:turn-na-2.kandy.io:443?transport=tcp",
+              ],
+            },
+            Object {
+              "urls": Array [
+                "stun:turn-na-1.kandy.io:3478?transport=udp",
+              ],
+            },
+            Object {
+              "urls": Array [
+                "stun:turn-na-2.kandy.io:3478?transport=udp",
+              ],
+            },
+          ],
+        },
       },
       "subscription": Object {
         "websocket": Object {


### PR DESCRIPTION
### Branch

develop

### Story

https://kandyio.atlassian.net/browse/KJS-379

### Description

This is a follow up from the PR https://github.com/Kandy-IO/Kandy.js/pull/3327
(The associated JIRA for above PR is: https://kandyio.atlassian.net/browse/KJS-370)

Basically we want customers that use our SDK in their apps, to use the new way of providing ice servers, just like our internal users provide it in our Test app. The only difference is that in our Test App we specify some extra properties but those are commented out as optional ones (in case user wants to enable them..)

### Tests

**Unit testing:**

- cd kandy-js-support
- yarn test test

Ensure all tests pass

**Follow up**

N/A