### PR TITLE
[KJS-920] Deploy latest versions of kandy-js-support repo to NPM

### DIFF
--- a/packages/link-config-emea/package.json
+++ b/packages/link-config-emea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kandy-io/link-config-emea",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Kandy.js EMEA Configuration",
   "author": "Jean-Yves Boudreau (jean-yves.boudreau@kandy.io)",
   "license": "MIT",

--- a/packages/link-config-uae/package.json
+++ b/packages/link-config-uae/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kandy-io/link-config-uae",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Kandy.js UAE Configuration",
   "author": "Jean-Yves Boudreau (jean-yves.boudreau@kandy.io)",
   "license": "MIT",

--- a/packages/link-config-us/package.json
+++ b/packages/link-config-us/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kandy-io/link-config-us",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Kandy.js US Configuration",
   "author": "Jean-Yves Boudreau (jean-yves.boudreau@kandy.io)",
   "license": "MIT",


### PR DESCRIPTION
### Branch
`master`

### Story
[KJS-920: Deploy latest versions of kandy-js-support repo to NPM](https://kandyio.atlassian.net/browse/KJS-920)

### Description
There is a mismatch between the CHANGELOG and package.json version numbers. This is a quick fix for that.